### PR TITLE
Tag bazel dockers with branch name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
+            type=ref,event=branch
             type=sha,format=long
 
       - name: Build and push Docker image


### PR DESCRIPTION
This is in preparation for pulling the bazel docker before building it to speedup the build.