### PR TITLE
Add sample grpc service

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,5 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
+# rules_python
+
 http_archive(
     name = "rules_python",
     sha256 = "cdf6b84084aad8f10bf20b46b77cb48d83c319ebe6458a18e9d2cebf57807cdd",
@@ -21,3 +23,38 @@ load("@my_deps//:requirements.bzl", "install_deps")
 
 # Call it to define repos for your requirements.
 install_deps()
+
+# rules_proto
+
+http_archive(
+    name = "rules_proto",
+    sha256 = "66bfdf8782796239d3875d37e7de19b1d94301e8972b3cbd2446b332429b4df1",
+    strip_prefix = "rules_proto-4.0.0",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_proto/archive/refs/tags/4.0.0.tar.gz",
+        "https://github.com/bazelbuild/rules_proto/archive/refs/tags/4.0.0.tar.gz",
+    ],
+)
+
+load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
+
+rules_proto_dependencies()
+
+rules_proto_toolchains()
+
+# com_github_grpc_grpc
+
+http_archive(
+    name = "com_github_grpc_grpc",
+    sha256 = "ec19657a677d49af59aa806ec299c070c882986c9fcc022b1c22c2a3caf01bcd",
+    strip_prefix = "grpc-1.45.0",
+    urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.45.0.tar.gz"],
+)
+
+load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+
+grpc_deps()
+
+load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+
+grpc_extra_deps()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,6 @@
+grpcio
+grpcio-tools
 numpy
+protobuf
+setuptools
+six

--- a/sample_service/BUILD
+++ b/sample_service/BUILD
@@ -1,0 +1,65 @@
+# gRPC Bazel BUILD file.
+#
+# Copyright 2019 The gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@com_github_grpc_grpc//bazel:python_rules.bzl", "py_grpc_library", "py_proto_library")
+load("@my_deps//:requirements.bzl", "requirement")
+
+proto_library(
+    name = "prime_proto",
+    srcs = ["prime.proto"],
+)
+
+py_proto_library(
+    name = "prime_proto_pb2",
+    deps = [":prime_proto"],
+)
+
+py_grpc_library(
+    name = "prime_proto_pb2_grpc",
+    srcs = [":prime_proto"],
+    deps = [":prime_proto_pb2"],
+)
+
+py_binary(
+    name = "client",
+    srcs = ["client.py"],
+    deps = [
+        ":prime_proto_pb2",
+        ":prime_proto_pb2_grpc",
+        requirement("grpcio-tools"),
+    ],
+)
+
+py_binary(
+    name = "server",
+    srcs = ["server.py"],
+    deps = [
+        requirement("grpcio-tools"),
+        ":prime_proto_pb2",
+        ":prime_proto_pb2_grpc",
+    ],
+)
+
+py_test(
+    name = "test/_multiprocessing_example_test",
+    srcs = ["test/_multiprocessing_example_test.py"],
+    data = [
+        ":client",
+        ":server",
+    ],
+)

--- a/sample_service/client.py
+++ b/sample_service/client.py
@@ -1,0 +1,94 @@
+# Copyright 2019 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""An example of multiprocessing concurrency with gRPC."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import argparse
+import atexit
+import logging
+import multiprocessing
+import operator
+import sys
+
+import grpc
+from sample_service import prime_pb2
+from sample_service import prime_pb2_grpc
+
+_PROCESS_COUNT = 8
+_MAXIMUM_CANDIDATE = 10000
+
+# Each worker process initializes a single channel after forking.
+# It's regrettable, but to ensure that each subprocess only has to instantiate
+# a single channel to be reused across all RPCs, we use globals.
+_worker_channel_singleton = None
+_worker_stub_singleton = None
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _shutdown_worker():
+    _LOGGER.info("Shutting worker process down.")
+    if _worker_channel_singleton is not None:
+        _worker_channel_singleton.stop()
+
+
+def _initialize_worker(server_address):
+    global _worker_channel_singleton  # pylint: disable=global-statement
+    global _worker_stub_singleton  # pylint: disable=global-statement
+    _LOGGER.info("Initializing worker process.")
+    _worker_channel_singleton = grpc.insecure_channel(server_address)
+    _worker_stub_singleton = prime_pb2_grpc.PrimeCheckerStub(_worker_channel_singleton)
+    atexit.register(_shutdown_worker)
+
+
+def _run_worker_query(primality_candidate):
+    _LOGGER.info("Checking primality of %s.", primality_candidate)
+    return _worker_stub_singleton.check(
+        prime_pb2.PrimeCandidate(candidate=primality_candidate)
+    )
+
+
+def _calculate_primes(server_address):
+    worker_pool = multiprocessing.Pool(
+        processes=_PROCESS_COUNT,
+        initializer=_initialize_worker,
+        initargs=(server_address,),
+    )
+    check_range = range(2, _MAXIMUM_CANDIDATE)
+    primality = worker_pool.map(_run_worker_query, check_range)
+    primes = zip(check_range, map(operator.attrgetter("isPrime"), primality))
+    return tuple(primes)
+
+
+def main():
+    msg = "Determine the primality of the first {} integers.".format(_MAXIMUM_CANDIDATE)
+    parser = argparse.ArgumentParser(description=msg)
+    parser.add_argument(
+        "server_address", help="The address of the server (e.g. localhost:50051)"
+    )
+    args = parser.parse_args()
+    primes = _calculate_primes(args.server_address)
+    print(primes)
+
+
+if __name__ == "__main__":
+    handler = logging.StreamHandler(sys.stdout)
+    formatter = logging.Formatter("[PID %(process)d] %(message)s")
+    handler.setFormatter(formatter)
+    _LOGGER.addHandler(handler)
+    _LOGGER.setLevel(logging.INFO)
+    main()

--- a/sample_service/prime.proto
+++ b/sample_service/prime.proto
@@ -1,0 +1,35 @@
+// Copyright 2019 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package prime;
+
+// A candidate integer for primality testing.
+message PrimeCandidate {
+    // The candidate.
+    int64 candidate = 1;
+}
+
+// The primality of the requested integer candidate.
+message Primality {
+    // Is the candidate prime?
+    bool isPrime = 1;
+}
+
+// Service to check primality.
+service PrimeChecker {
+    // Determines the primality of an integer.
+    rpc check (PrimeCandidate) returns (Primality) {}
+}

--- a/sample_service/server.py
+++ b/sample_service/server.py
@@ -1,0 +1,117 @@
+# Copyright 2019 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""An example of multiprocess concurrency with gRPC."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from concurrent import futures
+import contextlib
+import datetime
+import logging
+import math
+import multiprocessing
+import socket
+import sys
+import time
+
+import grpc
+from sample_service import prime_pb2
+from sample_service import prime_pb2_grpc
+
+_LOGGER = logging.getLogger(__name__)
+
+_ONE_DAY = datetime.timedelta(days=1)
+_PROCESS_COUNT = multiprocessing.cpu_count()
+_THREAD_CONCURRENCY = _PROCESS_COUNT
+
+
+def is_prime(n):
+    for i in range(2, int(math.ceil(math.sqrt(n)))):
+        if n % i == 0:
+            return False
+    else:
+        return True
+
+
+class PrimeChecker(prime_pb2_grpc.PrimeCheckerServicer):
+    def check(self, request, context):
+        _LOGGER.info("Determining primality of %s", request.candidate)
+        return prime_pb2.Primality(isPrime=is_prime(request.candidate))
+
+
+def _wait_forever(server):
+    try:
+        while True:
+            time.sleep(_ONE_DAY.total_seconds())
+    except KeyboardInterrupt:
+        server.stop(None)
+
+
+def _run_server(bind_address):
+    """Start a server in a subprocess."""
+    _LOGGER.info("Starting new server.")
+    options = (("grpc.so_reuseport", 1),)
+
+    server = grpc.server(
+        futures.ThreadPoolExecutor(
+            max_workers=_THREAD_CONCURRENCY,
+        ),
+        options=options,
+    )
+    prime_pb2_grpc.add_PrimeCheckerServicer_to_server(PrimeChecker(), server)
+    server.add_insecure_port(bind_address)
+    server.start()
+    _wait_forever(server)
+
+
+@contextlib.contextmanager
+def _reserve_port():
+    """Find and reserve a port for all subprocesses to use."""
+    sock = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
+    if sock.getsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT) == 0:
+        raise RuntimeError("Failed to set SO_REUSEPORT.")
+    sock.bind(("", 0))
+    try:
+        yield sock.getsockname()[1]
+    finally:
+        sock.close()
+
+
+def main():
+    with _reserve_port() as port:
+        bind_address = "localhost:{}".format(port)
+        _LOGGER.info("Binding to '%s'", bind_address)
+        sys.stdout.flush()
+        workers = []
+        for _ in range(_PROCESS_COUNT):
+            # NOTE: It is imperative that the worker subprocesses be forked before
+            # any gRPC servers start up. See
+            # https://github.com/grpc/grpc/issues/16001 for more details.
+            worker = multiprocessing.Process(target=_run_server, args=(bind_address,))
+            worker.start()
+            workers.append(worker)
+        for worker in workers:
+            worker.join()
+
+
+if __name__ == "__main__":
+    handler = logging.StreamHandler(sys.stdout)
+    formatter = logging.Formatter("[PID %(process)d] %(message)s")
+    handler.setFormatter(formatter)
+    _LOGGER.addHandler(handler)
+    _LOGGER.setLevel(logging.INFO)
+    main()

--- a/sample_service/test/_multiprocessing_example_test.py
+++ b/sample_service/test/_multiprocessing_example_test.py
@@ -1,0 +1,76 @@
+# Copyright 2019 the gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Test for multiprocessing example."""
+
+import ast
+import logging
+import math
+import os
+import re
+import subprocess
+import tempfile
+import unittest
+
+_BINARY_DIR = os.path.realpath(
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), "..")
+)
+_SERVER_PATH = os.path.join(_BINARY_DIR, "server")
+_CLIENT_PATH = os.path.join(_BINARY_DIR, "client")
+
+
+def is_prime(n):
+    for i in range(2, int(math.ceil(math.sqrt(n)))):
+        if n % i == 0:
+            return False
+    else:
+        return True
+
+
+def _get_server_address(server_stream):
+    while True:
+        server_stream.seek(0)
+        line = server_stream.readline()
+        while line:
+            matches = re.search("Binding to '(.+)'", line)
+            if matches is not None:
+                return matches.groups()[0]
+            line = server_stream.readline()
+
+
+class MultiprocessingExampleTest(unittest.TestCase):
+    def test_multiprocessing_example(self):
+        server_stdout = tempfile.TemporaryFile(mode="r")
+        server_process = subprocess.Popen((_SERVER_PATH,), stdout=server_stdout)
+        server_address = _get_server_address(server_stdout)
+        client_stdout = tempfile.TemporaryFile(mode="r")
+        client_process = subprocess.Popen(
+            (
+                _CLIENT_PATH,
+                server_address,
+            ),
+            stdout=client_stdout,
+        )
+        client_process.wait()
+        server_process.terminate()
+        client_stdout.seek(0)
+        results = ast.literal_eval(client_stdout.read().strip().split("\n")[-1])
+        values = tuple(result[0] for result in results)
+        self.assertSequenceEqual(range(2, 10000), values)
+        for result in results:
+            self.assertEqual(is_prime(result[0]), result[1])
+
+
+if __name__ == "__main__":
+    logging.basicConfig()
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Copy over the sample grpc service from:
https://github.com/grpc/grpc/tree/master/examples/python/multiprocessing

We also pull in a working set of protobuf/grpc bazel dependencies and
add the corresponding python dependencies.