### PR TITLE
Adjust cache key logic to work better with github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,9 +55,9 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.cache
-          key: cache-${{ github.ref_name }}
+          key: cache-${{ github.sha }}
           restore-keys: |
-            cache-main
+            cache-
 
       - name: Run tests in the previously built bazel docker
         run: |


### PR DESCRIPTION
GitHub actions caching will never update the cache if there was a cache
hit, but for bazel we want to do this since bazel guarantees hermetic
builds and will update the cache if needed. See
https://github.com/actions/cache/issues/109 for more context. As such,
we adjust the cache key logic to work better with github actions as per
the documentation:
https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#matching-a-cache-key
Now we will always have a cache miss and load the latest restore key and
then we will always upload to a new cache key. This adds a couple
minutes for saving the cache, but building from scratch is 12+ min, so
it is worth it.

Closes #8 